### PR TITLE
Add function for removing rules

### DIFF
--- a/src/Grammars.jl
+++ b/src/Grammars.jl
@@ -52,6 +52,8 @@ export
 
     store_cfg, 
     read_cfg,
-    add_rule!
+    add_rule!,
+    remove_rule!,
+    cleanup_removed_rules!
 
 end # module

--- a/src/cfg.jl
+++ b/src/cfg.jl
@@ -144,12 +144,9 @@ function cleanup_removed_rules!(g::ContextFreeGrammar)
 	end
 	# update bytype
 	empty!(g.bytype)
-	@show g.bytype
 
 	for (idx, type) ∈ enumerate(g.types)
 		g.bytype[type] = push!(get(g.bytype, type, Int[]), idx)
 	end
-	@show g.bytype
-	@show g
 	return g
 end

--- a/src/cfg.jl
+++ b/src/cfg.jl
@@ -5,7 +5,7 @@ Use the @grammar macro to create a Grammar object.
 """
 mutable struct ContextFreeGrammar <: Grammar
 	rules::Vector{Any}    # list of RHS of rules (subexpressions)
-	types::Vector{Symbol} # list of LHS of rules (types, all symbols)
+	types::Vector{Union{Symbol, Nothing}} # list of LHS of rules (types, all symbols)
 	isterminal::BitVector # whether rule i is terminal
 	iseval::BitVector     # whether rule i is an eval rule
 	bytype::Dict{Symbol,Vector{Int}}   # maps type to all rules of said type
@@ -87,26 +87,69 @@ Usage:
 ```
 The syntax is identical to the syntax of @csgrammar, but only single rules are supported.
 """
-function add_rule!(cfgrammar :: ContextFreeGrammar, e::Expr)
+function add_rule!(g::ContextFreeGrammar, e::Expr)
 	if e.head == :(=)
 		s = e.args[1]		# Name of return type
 		rule = e.args[2]	# expression?
 		rvec = Any[]
 		_parse_rule!(rvec, rule)
 		for r ∈ rvec
-			if r ∈ cfgrammar.rules
+			if r ∈ g.rules
 				continue
 			end
-			push!(cfgrammar.rules, r)
-			push!(cfgrammar.iseval, iseval(rule))
-			push!(cfgrammar.types, s)
-			cfgrammar.bytype[s] = push!(get(cfgrammar.bytype, s, Int[]), length(cfgrammar.rules))
+			push!(g.rules, r)
+			push!(g.iseval, iseval(rule))
+			push!(g.types, s)
+			g.bytype[s] = push!(get(g.bytype, s, Int[]), length(g.rules))
 		end
 	end
-	alltypes = collect(keys(cfgrammar.bytype))
+	alltypes = collect(keys(g.bytype))
 
 	# is_terminal and childtypes need to be recalculated from scratch, since a new type might 
 	# be added that was used as a terminal symbol before.
-	cfgrammar.isterminal = [isterminal(rule, alltypes) for rule ∈ cfgrammar.rules]
-	cfgrammar.childtypes = [get_childtypes(rule, alltypes) for rule ∈ cfgrammar.rules]
+	g.isterminal = [isterminal(rule, alltypes) for rule ∈ g.rules]
+	g.childtypes = [get_childtypes(rule, alltypes) for rule ∈ g.rules]
+	return g
+end
+
+"""
+Removes the rule corresponding to `idx` from the grammar. 
+In order to avoid shifting indices, the rule is replaced with `nothing`,
+and all other data structures are updated accordingly.
+"""
+function remove_rule!(g::ContextFreeGrammar, idx::Int)
+	type = g.types[idx]
+	g.rules[idx] = nothing
+	g.iseval[idx] = false
+	g.types[idx] = nothing
+	deleteat!(g.bytype[type], findall(isequal(idx), g.bytype[type]))
+	if length(g.bytype[type]) == 0
+		# remove type
+		delete!(g.bytype, type)
+		alltypes = collect(keys(g.bytype))
+		g.isterminal = [isterminal(rule, alltypes) for rule ∈ g.rules]
+		g.childtypes = [get_childtypes(rule, alltypes) for rule ∈ g.rules]
+	end
+	return g
+end
+
+"""
+Removes any placeholders for previously deleted rules. This means that indices get shifted.
+"""
+function cleanup_removed_rules!(g::ContextFreeGrammar)
+	rules_to_cleanup = findall(isequal(nothing), g.rules)
+	# highest indices are removed first, otherwise their index will have shifted
+	for v ∈ [g.rules, g.types, g.isterminal, g.iseval, g.childtypes]
+		deleteat!(v, rules_to_cleanup)
+	end
+	# update bytype
+	empty!(g.bytype)
+	@show g.bytype
+
+	for (idx, type) ∈ enumerate(g.types)
+		g.bytype[type] = push!(get(g.bytype, type, Int[]), idx)
+	end
+	@show g.bytype
+	@show g
+	return g
 end


### PR DESCRIPTION
Adds:

- A function for removing rules without re-indexing, so that existing rulenode trees that do not make use of the removed rule remain valid.
- A function for cleaning up removed rules (re-indexing)

Search works without any modifications when rules are removed but not cleaned up:

```julia
g₁ = Herb.Grammars.@cfgrammar begin
    Real = |(0:9)
    Real = x
    Real = Real + Real
    Real = Real * Real
end

Herb.Grammars.remove_rule!(g₁, 13) # Delete multiplication rule
problem = Herb.Data.Problem([Herb.Data.IOExample(Dict(:x => x), 3x+5) for x ∈ 1:5], "example")
Herb.Search.enumerative_search(g₁, problem, 3, Herb.Search.ContextFreeBFSEnumerator)
```
Output:
```julia
:((5 + x) + (x + x))
```