### PR TITLE
Constraint propagation solver and new hole types (4 PRs)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ HerbCore = "2b23ba43-8213-43cb-b5ea-38c12b45bd45"
 AbstractTrees = "0.4"
 DataStructures = "0.17,0.18"
 TreeView = "0.5"
-HerbCore = "0.1.0"
+HerbCore = "0.2.0"
 julia = "1.8"
 
 [extras]

--- a/src/csg/csg.jl
+++ b/src/csg/csg.jl
@@ -1,8 +1,8 @@
 """
-	ContextSensitiveGrammar <: Grammar
+	ContextSensitiveGrammar <: AbstractGrammar
 
 Represents a context-sensitive grammar.
-Extends [`Grammar`](@ref) with constraints.
+Extends [`AbstractGrammar`](@ref) with constraints.
 
 Consists of:
 
@@ -23,7 +23,7 @@ Consists of:
 Use the [`@csgrammar`](@ref) macro to create a [`ContextSensitiveGrammar`](@ref) object.
 Use the [`@pcsgrammar`](@ref) macro to create a [`ContextSensitiveGrammar`](@ref) object with probabilities.
 """
-mutable struct ContextSensitiveGrammar <: Grammar
+mutable struct ContextSensitiveGrammar <: AbstractGrammar
 	rules::Vector{Any}
 	types::Vector{Union{Symbol, Nothing}}
 	isterminal::BitVector
@@ -194,11 +194,11 @@ function Base.display(rulenode::RuleNode, grammar::ContextSensitiveGrammar)
 end
 
 """
-	merge_grammars!(merge_to::Grammar, merge_from::Grammar)
+	merge_grammars!(merge_to::AbstractGrammar, merge_from::AbstractGrammar)
 
 Adds all rules and constraints from `merge_from` to `merge_to`.
 """
-function merge_grammars!(merge_to::Grammar, merge_from::Grammar)
+function merge_grammars!(merge_to::AbstractGrammar, merge_from::AbstractGrammar)
 	for i in eachindex(merge_from.rules)
 		expression = :($(merge_from.types[i]) = $(merge_from.rules[i]))
 		add_rule!(merge_to, expression)

--- a/src/csg/probabilistic_csg.jl
+++ b/src/csg/probabilistic_csg.jl
@@ -52,8 +52,9 @@ function expr2pcsgrammar(ex::Expr)::ContextSensitiveGrammar
 	is_eval = [iseval(rule) for rule in rules]
 	childtypes = [get_childtypes(rule, alltypes) for rule in rules]
 	domains = Dict(type => BitArray(r ∈ bytype[type] for r ∈ 1:length(rules)) for type ∈ alltypes)
-	
-	normalize!(ContextSensitiveGrammar(rules, types, is_terminal, is_eval, bytype, domains, childtypes, log_probabilities))
+	bychildtypes = [BitVector([childtypes[i1] == childtypes[i2] for i2 ∈ 1:length(rules)]) for i1 ∈ 1:length(rules)]
+
+	normalize!(ContextSensitiveGrammar(rules, types, is_terminal, is_eval, bytype, domains, childtypes, bychildtypes, log_probabilities))
 end
 
 """

--- a/src/grammar_base.jl
+++ b/src/grammar_base.jl
@@ -1,5 +1,5 @@
 """
-	isterminal(rule::Any, types::AbstractVector{Symbol})
+    isterminal(rule::Any, types::AbstractVector{Symbol})
 
 Returns true if the rule is terminal, i.e., it does not contain any of the types in the provided vector.
 For example, :(x) is terminal, and :(1+1) is terminal, but :(Real + Real) is typically not.
@@ -17,19 +17,19 @@ end
 
 
 """
-	iseval(rule)
+    iseval(rule)
 
 Returns true if the rule is the special evaluate immediately function, i.e., _()
 
 !!! compat
-	evaluate immediately functionality is not yet supported by most of Herb.jl
+    evaluate immediately functionality is not yet supported by most of Herb.jl
 """
 iseval(rule) = false
 iseval(rule::Expr) = (rule.head == :call && rule.args[1] == :_)
 
 
 """
-	get_childtypes(rule::Any, types::AbstractVector{Symbol})
+    get_childtypes(rule::Any, types::AbstractVector{Symbol})
 
 Returns the child types/nonterminals of a production rule.
 """
@@ -48,7 +48,7 @@ end
 Base.getindex(grammar::AbstractGrammar, typ::Symbol) = grammar.bytype[typ]
 
 """
-	nonterminals(grammar::AbstractGrammar)::Vector{Symbol}
+    nonterminals(grammar::AbstractGrammar)::Vector{Symbol}
 
 Returns a list of the nonterminals or types in the [`AbstractGrammar`](@ref).
 """
@@ -56,7 +56,7 @@ nonterminals(grammar::AbstractGrammar)::Vector{Symbol} = collect(keys(grammar.by
 
 
 """
-	return_type(grammar::AbstractGrammar, rule_index::Int)::Symbol
+    return_type(grammar::AbstractGrammar, rule_index::Int)::Symbol
 
 Returns the type of the production rule at `rule_index`.
 """
@@ -64,7 +64,7 @@ return_type(grammar::AbstractGrammar, rule_index::Int) = grammar.types[rule_inde
 
 
 """
-	child_types(grammar::AbstractGrammar, rule_index::Int)
+    child_types(grammar::AbstractGrammar, rule_index::Int)
 
 Returns the types of the children (nonterminals) of the production rule at `rule_index`.
 """
@@ -72,20 +72,20 @@ child_types(grammar::AbstractGrammar, rule_index::Int) = grammar.childtypes[rule
 
 
 """
-	get_domain(g::AbstractGrammar, type::Symbol)::BitVector
+    get_domain(g::AbstractGrammar, type::Symbol)::BitVector
 
 Returns the domain for the hole of a certain type as a `BitVector` of the same length as the number of 
 rules in the grammar. Bit `i` is set to `true` iff rule `i` is of type `type`.
 
 !!! info
-	Since this function can be intensively used when exploring a program space defined by a grammar,
-	the outcomes of this function are precomputed and stored in the `domains` field in a [`AbstractGrammar`](@ref).
+    Since this function can be intensively used when exploring a program space defined by a grammar,
+    the outcomes of this function are precomputed and stored in the `domains` field in a [`AbstractGrammar`](@ref).
 """
 get_domain(g::AbstractGrammar, type::Symbol)::BitVector = deepcopy(g.domains[type])
 
 
 """
-	get_domain(g::AbstractGrammar, rules::Vector{Int})::BitVector
+    get_domain(g::AbstractGrammar, rules::Vector{Int})::BitVector
 
 Takes a domain `rules` defined as a vector of ints and converts it to a domain defined as a `BitVector`.
 """
@@ -93,7 +93,7 @@ get_domain(g::AbstractGrammar, rules::Vector{Int})::BitVector = BitArray(r ∈ r
 
 
 """
-	isterminal(grammar::AbstractGrammar, rule_index::Int)::Bool
+    isterminal(grammar::AbstractGrammar, rule_index::Int)::Bool
 
 Returns true if the production rule at `rule_index` is terminal, i.e., does not contain any nonterminal symbols.
 """
@@ -101,66 +101,66 @@ isterminal(grammar::AbstractGrammar, rule_index::Int)::Bool = grammar.isterminal
 
 
 """
-	iseval(grammar::AbstractGrammar)::Bool
+    iseval(grammar::AbstractGrammar)::Bool
 
 Returns true if any production rules in grammar contain the special _() eval function.
 
 !!! compat
-	evaluate immediately functionality is not yet supported by most of Herb.jl
+    evaluate immediately functionality is not yet supported by most of Herb.jl
 
 """
 iseval(grammar::AbstractGrammar)::Bool = any(grammar.iseval)
 
 
 """
-	iseval(grammar::AbstractGrammar, index::Int)::Bool
+    iseval(grammar::AbstractGrammar, index::Int)::Bool
 
 Returns true if the production rule at rule_index contains the special _() eval function.
 
 !!! compat
-	evaluate immediately functionality is not yet supported by most of Herb.jl
+    evaluate immediately functionality is not yet supported by most of Herb.jl
 
 """
 iseval(grammar::AbstractGrammar, index::Int)::Bool = grammar.iseval[index]
 
 
 """
-	log_probability(grammar::AbstractGrammar, index::Int)::Real
+    log_probability(grammar::AbstractGrammar, index::Int)::Real
 
 Returns the log probability for the rule at `index` in the grammar.
-	
+    
 !!! warning
-	If the grammar is not probabilistic, a warning is displayed, and a uniform probability is assumed.
+    If the grammar is not probabilistic, a warning is displayed, and a uniform probability is assumed.
 """
 function log_probability(grammar::AbstractGrammar, index::Int)::Real
-	if !isprobabilistic(grammar)
-		@warn "Requesting probability in a non-probabilistic grammar.\nUniform distribution is assumed."
-		# Assume uniform probability
-		return log(1 / length(grammar.bytype[grammar.types[index]]))
-	end
-	return grammar.log_probabilities[index]
+    if !isprobabilistic(grammar)
+        @warn "Requesting probability in a non-probabilistic grammar.\nUniform distribution is assumed."
+        # Assume uniform probability
+        return log(1 / length(grammar.bytype[grammar.types[index]]))
+    end
+    return grammar.log_probabilities[index]
 end
 
 """
-	probability(grammar::AbstractGrammar, index::Int)::Real
+    probability(grammar::AbstractGrammar, index::Int)::Real
 
 Return the probability for a rule in the grammar.
 Use [`log_probability`](@ref) whenever possible.
 
 !!! warning
-	If the grammar is not probabilistic, a warning is displayed, and a uniform probability is assumed.
+    If the grammar is not probabilistic, a warning is displayed, and a uniform probability is assumed.
 """
 function probability(grammar::AbstractGrammar, index::Int)::Real
-	if !isprobabilistic(grammar)
-		@warn "Requesting probability in a non-probabilistic grammar.\nUniform distribution is assumed."
-		# Assume uniform probability
-		return 1 / length(grammar.bytype[grammar.types[index]])
-	end
-	return ℯ^grammar.log_probabilities[index]
+    if !isprobabilistic(grammar)
+        @warn "Requesting probability in a non-probabilistic grammar.\nUniform distribution is assumed."
+        # Assume uniform probability
+        return 1 / length(grammar.bytype[grammar.types[index]])
+    end
+    return ℯ^grammar.log_probabilities[index]
 end
 
 """
-	isprobabilistic(grammar::AbstractGrammar)::Bool
+    isprobabilistic(grammar::AbstractGrammar)::Bool
 
 Function returns whether a [`AbstractGrammar`](@ref) is probabilistic.
 """
@@ -168,7 +168,7 @@ isprobabilistic(grammar::AbstractGrammar)::Bool = !(grammar.log_probabilities �
 
 
 """
-	nchildren(grammar::AbstractGrammar, rule_index::Int)::Int
+    nchildren(grammar::AbstractGrammar, rule_index::Int)::Int
 
 Returns the number of children (nonterminals) of the production rule at `rule_index`.
 """
@@ -176,7 +176,7 @@ nchildren(grammar::AbstractGrammar, rule_index::Int)::Int = length(grammar.child
 
 
 """
-	max_arity(grammar::AbstractGrammar)::Int
+    max_arity(grammar::AbstractGrammar)::Int
 
 Returns the maximum arity (number of children) over all production rules in the [`AbstractGrammar`](@ref).
 """
@@ -184,121 +184,121 @@ max_arity(grammar::AbstractGrammar)::Int = maximum(length(cs) for cs in grammar.
 
 
 function Base.show(io::IO, grammar::AbstractGrammar)
-	for i in eachindex(grammar.rules)
-	    println(io, i, ": ", grammar.types[i], " = ", grammar.rules[i])
-	end
+    for i in eachindex(grammar.rules)
+        println(io, i, ": ", grammar.types[i], " = ", grammar.rules[i])
+    end
 end
 
 
 """
-	add_rule!(g::AbstractGrammar, e::Expr)
+    add_rule!(g::AbstractGrammar, e::Expr)
 
 Adds a rule to the grammar. 
 
 ### Usage: 
 ```
-	add_rule!(grammar, :("Real = Real + Real"))
+    add_rule!(grammar, :("Real = Real + Real"))
 ```
 The syntax is identical to the syntax of [`@csgrammar`](@ref) and [`@cfgrammar`](@ref), but only single rules are supported.
 
 !!! warning
-	Calls to this function are ignored if a rule is already in the grammar.
+    Calls to this function are ignored if a rule is already in the grammar.
 """
 function add_rule!(g::AbstractGrammar, e::Expr)
-	if e.head == :(=) && typeof(e.args[1]) == Symbol
-		s = e.args[1]		# Name of return type
-		rule = e.args[2]	# expression?
-		rvec = Any[]
-		parse_rule!(rvec, rule)
-		for r ∈ rvec
-			# Only add a rule if it does not exist yet. Check for existance
-			# with strict equality so that true and 1 are not considered
-			# equal. that means we can't use `in` or `∈` for equality checking.
-			if !any(r === rule for rule ∈ g.rules)
-				push!(g.rules, r)
-				push!(g.iseval, iseval(rule))
-				push!(g.types, s)
-				g.bytype[s] = push!(get(g.bytype, s, Int[]), length(g.rules))
-			end
-		end
-	else
-		throw(ArgumentError("Invalid rule: $e. Rules must be of the form `Symbol = Expr`"))
-	end
-	alltypes = collect(keys(g.bytype))
+    if e.head == :(=) && typeof(e.args[1]) == Symbol
+        s = e.args[1]		# Name of return type
+        rule = e.args[2]	# expression?
+        rvec = Any[]
+        parse_rule!(rvec, rule)
+        for r ∈ rvec
+            # Only add a rule if it does not exist yet. Check for existance
+            # with strict equality so that true and 1 are not considered
+            # equal. that means we can't use `in` or `∈` for equality checking.
+            if !any(r === rule for rule ∈ g.rules)
+                push!(g.rules, r)
+                push!(g.iseval, iseval(rule))
+                push!(g.types, s)
+                g.bytype[s] = push!(get(g.bytype, s, Int[]), length(g.rules))
+            end
+        end
+    else
+        throw(ArgumentError("Invalid rule: $e. Rules must be of the form `Symbol = Expr`"))
+    end
+    alltypes = collect(keys(g.bytype))
 
-	# is_terminal and childtypes need to be recalculated from scratch, since a new type might 
-	# be added that was used as a terminal symbol before.
-	g.isterminal = [isterminal(rule, alltypes) for rule ∈ g.rules]
-	g.childtypes = [get_childtypes(rule, alltypes) for rule ∈ g.rules]
-	g.bychildtypes = [BitVector([g.childtypes[i1] == g.childtypes[i2] for i2 ∈ 1:length(g.rules)]) for i1 ∈ 1:length(g.rules)]
-	g.domains = Dict(type => BitArray(r ∈ g.bytype[type] for r ∈ 1:length(g.rules)) for type ∈ keys(g.bytype))
-	return g
+    # is_terminal and childtypes need to be recalculated from scratch, since a new type might 
+    # be added that was used as a terminal symbol before.
+    g.isterminal = [isterminal(rule, alltypes) for rule ∈ g.rules]
+    g.childtypes = [get_childtypes(rule, alltypes) for rule ∈ g.rules]
+    g.bychildtypes = [BitVector([g.childtypes[i1] == g.childtypes[i2] for i2 ∈ 1:length(g.rules)]) for i1 ∈ 1:length(g.rules)]
+    g.domains = Dict(type => BitArray(r ∈ g.bytype[type] for r ∈ 1:length(g.rules)) for type ∈ keys(g.bytype))
+    return g
 end
 
 """
 Adds a probabilistic derivation rule.
 """
 function add_rule!(g::AbstractGrammar, p::Real, e::Expr)
-	isprobabilistic(g) || throw(ArgumentError("adding a probabilistic rule to a non-probabilistic grammar"))
-	len₀ = length(g.rules)
-	add_rule!(g, e)
-	len₁ = length(g.rules)
-	nnew = len₁ - len₀
-	append!(g.log_probabilities, repeat([log(p / nnew)], nnew))
-	normalize!(g)
+    isprobabilistic(g) || throw(ArgumentError("adding a probabilistic rule to a non-probabilistic grammar"))
+    len₀ = length(g.rules)
+    add_rule!(g, e)
+    len₁ = length(g.rules)
+    nnew = len₁ - len₀
+    append!(g.log_probabilities, repeat([log(p / nnew)], nnew))
+    normalize!(g)
 end
 
 """
-	remove_rule!(g::AbstractGrammar, idx::Int)
+    remove_rule!(g::AbstractGrammar, idx::Int)
 
 Removes the rule corresponding to `idx` from the grammar. 
 In order to avoid shifting indices, the rule is replaced with `nothing`,
 and all other data structures are updated accordingly.
 """
 function remove_rule!(g::AbstractGrammar, idx::Int)
-	type = g.types[idx]
-	g.rules[idx] = nothing
-	g.iseval[idx] = false
-	g.types[idx] = nothing
-	deleteat!(g.bytype[type], findall(isequal(idx), g.bytype[type]))
-	if length(g.bytype[type]) == 0
-		# remove type
-		delete!(g.bytype, type)
-		alltypes = collect(keys(g.bytype))
-		g.isterminal = [isterminal(rule, alltypes) for rule ∈ g.rules]
-		g.childtypes = [get_childtypes(rule, alltypes) for rule ∈ g.rules]
-		g.bychildtypes = [BitVector([g.childtypes[i1] == g.childtypes[i2] for i2 ∈ 1:length(g.rules)]) for i1 ∈ 1:length(g.rules)]
-	end
-	for domain ∈ values(g.domains)
-		domain[idx] = 0
-	end
-	return g
+    type = g.types[idx]
+    g.rules[idx] = nothing
+    g.iseval[idx] = false
+    g.types[idx] = nothing
+    deleteat!(g.bytype[type], findall(isequal(idx), g.bytype[type]))
+    if length(g.bytype[type]) == 0
+        # remove type
+        delete!(g.bytype, type)
+        alltypes = collect(keys(g.bytype))
+        g.isterminal = [isterminal(rule, alltypes) for rule ∈ g.rules]
+        g.childtypes = [get_childtypes(rule, alltypes) for rule ∈ g.rules]
+        g.bychildtypes = [BitVector([g.childtypes[i1] == g.childtypes[i2] for i2 ∈ 1:length(g.rules)]) for i1 ∈ 1:length(g.rules)]
+    end
+    for domain ∈ values(g.domains)
+        domain[idx] = 0
+    end
+    return g
 end
 
 
 """
-	cleanup_removed_rules!(g::AbstractGrammar)
+    cleanup_removed_rules!(g::AbstractGrammar)
 
 Removes any placeholders for previously deleted rules. 
 This means that indices get shifted.
 
 !!! warning
-	When indices are shifted, this grammar can no longer be used to interpret 
-	[`AbstractRuleNode`](@ref) trees created before the call to this function.
-	These trees become meaningless. 
+    When indices are shifted, this grammar can no longer be used to interpret 
+    [`AbstractRuleNode`](@ref) trees created before the call to this function.
+    These trees become meaningless. 
 """
 function cleanup_removed_rules!(g::AbstractGrammar)
-	rules_to_cleanup = findall(isequal(nothing), g.rules)
-	# highest indices are removed first, otherwise their index will have shifted
-	for v ∈ [g.rules, g.types, g.isterminal, g.iseval, g.childtypes]
-		deleteat!(v, rules_to_cleanup)
-	end
-	# update bytype
-	empty!(g.bytype)
+    rules_to_cleanup = findall(isequal(nothing), g.rules)
+    # highest indices are removed first, otherwise their index will have shifted
+    for v ∈ [g.rules, g.types, g.isterminal, g.iseval, g.childtypes]
+        deleteat!(v, rules_to_cleanup)
+    end
+    # update bytype
+    empty!(g.bytype)
 
-	for (idx, type) ∈ enumerate(g.types)
-		g.bytype[type] = push!(get(g.bytype, type, Int[]), idx)
-	end
-	g.domains = Dict(type => BitArray(r ∈ g.bytype[type] for r ∈ 1:length(g.rules)) for type ∈ keys(g.bytype))
-	return g
+    for (idx, type) ∈ enumerate(g.types)
+        g.bytype[type] = push!(get(g.bytype, type, Int[]), idx)
+    end
+    g.domains = Dict(type => BitArray(r ∈ g.bytype[type] for r ∈ 1:length(g.rules)) for type ∈ keys(g.bytype))
+    return g
 end

--- a/src/grammar_base.jl
+++ b/src/grammar_base.jl
@@ -45,63 +45,63 @@ function get_childtypes(rule::Any, types::AbstractVector{Symbol})
     return retval
 end
 
-Base.getindex(grammar::Grammar, typ::Symbol) = grammar.bytype[typ]
+Base.getindex(grammar::AbstractGrammar, typ::Symbol) = grammar.bytype[typ]
 
 """
-	nonterminals(grammar::Grammar)::Vector{Symbol}
+	nonterminals(grammar::AbstractGrammar)::Vector{Symbol}
 
-Returns a list of the nonterminals or types in the [`Grammar`](@ref).
+Returns a list of the nonterminals or types in the [`AbstractGrammar`](@ref).
 """
-nonterminals(grammar::Grammar)::Vector{Symbol} = collect(keys(grammar.bytype))
+nonterminals(grammar::AbstractGrammar)::Vector{Symbol} = collect(keys(grammar.bytype))
 
 
 """
-	return_type(grammar::Grammar, rule_index::Int)::Symbol
+	return_type(grammar::AbstractGrammar, rule_index::Int)::Symbol
 
 Returns the type of the production rule at `rule_index`.
 """
-return_type(grammar::Grammar, rule_index::Int) = grammar.types[rule_index]
+return_type(grammar::AbstractGrammar, rule_index::Int) = grammar.types[rule_index]
 
 
 """
-	child_types(grammar::Grammar, rule_index::Int)
+	child_types(grammar::AbstractGrammar, rule_index::Int)
 
 Returns the types of the children (nonterminals) of the production rule at `rule_index`.
 """
-child_types(grammar::Grammar, rule_index::Int) = grammar.childtypes[rule_index]
+child_types(grammar::AbstractGrammar, rule_index::Int) = grammar.childtypes[rule_index]
 
 
 """
-	get_domain(g::Grammar, type::Symbol)::BitVector
+	get_domain(g::AbstractGrammar, type::Symbol)::BitVector
 
 Returns the domain for the hole of a certain type as a `BitVector` of the same length as the number of 
 rules in the grammar. Bit `i` is set to `true` iff rule `i` is of type `type`.
 
 !!! info
 	Since this function can be intensively used when exploring a program space defined by a grammar,
-	the outcomes of this function are precomputed and stored in the `domains` field in a [`Grammar`](@ref).
+	the outcomes of this function are precomputed and stored in the `domains` field in a [`AbstractGrammar`](@ref).
 """
-get_domain(g::Grammar, type::Symbol)::BitVector = deepcopy(g.domains[type])
+get_domain(g::AbstractGrammar, type::Symbol)::BitVector = deepcopy(g.domains[type])
 
 
 """
-	get_domain(g::Grammar, rules::Vector{Int})::BitVector
+	get_domain(g::AbstractGrammar, rules::Vector{Int})::BitVector
 
 Takes a domain `rules` defined as a vector of ints and converts it to a domain defined as a `BitVector`.
 """
-get_domain(g::Grammar, rules::Vector{Int})::BitVector = BitArray(r ∈ rules for r ∈ 1:length(g.rules))
+get_domain(g::AbstractGrammar, rules::Vector{Int})::BitVector = BitArray(r ∈ rules for r ∈ 1:length(g.rules))
 
 
 """
-	isterminal(grammar::Grammar, rule_index::Int)::Bool
+	isterminal(grammar::AbstractGrammar, rule_index::Int)::Bool
 
 Returns true if the production rule at `rule_index` is terminal, i.e., does not contain any nonterminal symbols.
 """
-isterminal(grammar::Grammar, rule_index::Int)::Bool = grammar.isterminal[rule_index]
+isterminal(grammar::AbstractGrammar, rule_index::Int)::Bool = grammar.isterminal[rule_index]
 
 
 """
-	iseval(grammar::Grammar)::Bool
+	iseval(grammar::AbstractGrammar)::Bool
 
 Returns true if any production rules in grammar contain the special _() eval function.
 
@@ -109,11 +109,11 @@ Returns true if any production rules in grammar contain the special _() eval fun
 	evaluate immediately functionality is not yet supported by most of Herb.jl
 
 """
-iseval(grammar::Grammar)::Bool = any(grammar.iseval)
+iseval(grammar::AbstractGrammar)::Bool = any(grammar.iseval)
 
 
 """
-	iseval(grammar::Grammar, index::Int)::Bool
+	iseval(grammar::AbstractGrammar, index::Int)::Bool
 
 Returns true if the production rule at rule_index contains the special _() eval function.
 
@@ -121,18 +121,18 @@ Returns true if the production rule at rule_index contains the special _() eval 
 	evaluate immediately functionality is not yet supported by most of Herb.jl
 
 """
-iseval(grammar::Grammar, index::Int)::Bool = grammar.iseval[index]
+iseval(grammar::AbstractGrammar, index::Int)::Bool = grammar.iseval[index]
 
 
 """
-	log_probability(grammar::Grammar, index::Int)::Real
+	log_probability(grammar::AbstractGrammar, index::Int)::Real
 
 Returns the log probability for the rule at `index` in the grammar.
 	
 !!! warning
 	If the grammar is not probabilistic, a warning is displayed, and a uniform probability is assumed.
 """
-function log_probability(grammar::Grammar, index::Int)::Real
+function log_probability(grammar::AbstractGrammar, index::Int)::Real
 	if !isprobabilistic(grammar)
 		@warn "Requesting probability in a non-probabilistic grammar.\nUniform distribution is assumed."
 		# Assume uniform probability
@@ -142,7 +142,7 @@ function log_probability(grammar::Grammar, index::Int)::Real
 end
 
 """
-	probability(grammar::Grammar, index::Int)::Real
+	probability(grammar::AbstractGrammar, index::Int)::Real
 
 Return the probability for a rule in the grammar.
 Use [`log_probability`](@ref) whenever possible.
@@ -150,7 +150,7 @@ Use [`log_probability`](@ref) whenever possible.
 !!! warning
 	If the grammar is not probabilistic, a warning is displayed, and a uniform probability is assumed.
 """
-function probability(grammar::Grammar, index::Int)::Real
+function probability(grammar::AbstractGrammar, index::Int)::Real
 	if !isprobabilistic(grammar)
 		@warn "Requesting probability in a non-probabilistic grammar.\nUniform distribution is assumed."
 		# Assume uniform probability
@@ -160,30 +160,30 @@ function probability(grammar::Grammar, index::Int)::Real
 end
 
 """
-	isprobabilistic(grammar::Grammar)::Bool
+	isprobabilistic(grammar::AbstractGrammar)::Bool
 
-Function returns whether a [`Grammar`](@ref) is probabilistic.
+Function returns whether a [`AbstractGrammar`](@ref) is probabilistic.
 """
-isprobabilistic(grammar::Grammar)::Bool = !(grammar.log_probabilities ≡ nothing)
+isprobabilistic(grammar::AbstractGrammar)::Bool = !(grammar.log_probabilities ≡ nothing)
 
 
 """
-	nchildren(grammar::Grammar, rule_index::Int)::Int
+	nchildren(grammar::AbstractGrammar, rule_index::Int)::Int
 
 Returns the number of children (nonterminals) of the production rule at `rule_index`.
 """
-nchildren(grammar::Grammar, rule_index::Int)::Int = length(grammar.childtypes[rule_index])
+nchildren(grammar::AbstractGrammar, rule_index::Int)::Int = length(grammar.childtypes[rule_index])
 
 
 """
-	max_arity(grammar::Grammar)::Int
+	max_arity(grammar::AbstractGrammar)::Int
 
-Returns the maximum arity (number of children) over all production rules in the [`Grammar`](@ref).
+Returns the maximum arity (number of children) over all production rules in the [`AbstractGrammar`](@ref).
 """
-max_arity(grammar::Grammar)::Int = maximum(length(cs) for cs in grammar.childtypes)
+max_arity(grammar::AbstractGrammar)::Int = maximum(length(cs) for cs in grammar.childtypes)
 
 
-function Base.show(io::IO, grammar::Grammar)
+function Base.show(io::IO, grammar::AbstractGrammar)
 	for i in eachindex(grammar.rules)
 	    println(io, i, ": ", grammar.types[i], " = ", grammar.rules[i])
 	end
@@ -191,7 +191,7 @@ end
 
 
 """
-	add_rule!(g::Grammar, e::Expr)
+	add_rule!(g::AbstractGrammar, e::Expr)
 
 Adds a rule to the grammar. 
 
@@ -204,7 +204,7 @@ The syntax is identical to the syntax of [`@csgrammar`](@ref) and [`@cfgrammar`]
 !!! warning
 	Calls to this function are ignored if a rule is already in the grammar.
 """
-function add_rule!(g::Grammar, e::Expr)
+function add_rule!(g::AbstractGrammar, e::Expr)
 	if e.head == :(=) && typeof(e.args[1]) == Symbol
 		s = e.args[1]		# Name of return type
 		rule = e.args[2]	# expression?
@@ -238,7 +238,7 @@ end
 """
 Adds a probabilistic derivation rule.
 """
-function add_rule!(g::Grammar, p::Real, e::Expr)
+function add_rule!(g::AbstractGrammar, p::Real, e::Expr)
 	isprobabilistic(g) || throw(ArgumentError("adding a probabilistic rule to a non-probabilistic grammar"))
 	len₀ = length(g.rules)
 	add_rule!(g, e)
@@ -249,13 +249,13 @@ function add_rule!(g::Grammar, p::Real, e::Expr)
 end
 
 """
-	remove_rule!(g::Grammar, idx::Int)
+	remove_rule!(g::AbstractGrammar, idx::Int)
 
 Removes the rule corresponding to `idx` from the grammar. 
 In order to avoid shifting indices, the rule is replaced with `nothing`,
 and all other data structures are updated accordingly.
 """
-function remove_rule!(g::Grammar, idx::Int)
+function remove_rule!(g::AbstractGrammar, idx::Int)
 	type = g.types[idx]
 	g.rules[idx] = nothing
 	g.iseval[idx] = false
@@ -277,7 +277,7 @@ end
 
 
 """
-	cleanup_removed_rules!(g::Grammar)
+	cleanup_removed_rules!(g::AbstractGrammar)
 
 Removes any placeholders for previously deleted rules. 
 This means that indices get shifted.
@@ -287,7 +287,7 @@ This means that indices get shifted.
 	[`AbstractRuleNode`](@ref) trees created before the call to this function.
 	These trees become meaningless. 
 """
-function cleanup_removed_rules!(g::Grammar)
+function cleanup_removed_rules!(g::AbstractGrammar)
 	rules_to_cleanup = findall(isequal(nothing), g.rules)
 	# highest indices are removed first, otherwise their index will have shifted
 	for v ∈ [g.rules, g.types, g.isterminal, g.iseval, g.childtypes]

--- a/src/grammar_base.jl
+++ b/src/grammar_base.jl
@@ -230,6 +230,7 @@ function add_rule!(g::Grammar, e::Expr)
 	# be added that was used as a terminal symbol before.
 	g.isterminal = [isterminal(rule, alltypes) for rule ∈ g.rules]
 	g.childtypes = [get_childtypes(rule, alltypes) for rule ∈ g.rules]
+	g.bychildtypes = [BitVector([g.childtypes[i1] == g.childtypes[i2] for i2 ∈ 1:length(g.rules)]) for i1 ∈ 1:length(g.rules)]
 	g.domains = Dict(type => BitArray(r ∈ g.bytype[type] for r ∈ 1:length(g.rules)) for type ∈ keys(g.bytype))
 	return g
 end
@@ -266,6 +267,7 @@ function remove_rule!(g::Grammar, idx::Int)
 		alltypes = collect(keys(g.bytype))
 		g.isterminal = [isterminal(rule, alltypes) for rule ∈ g.rules]
 		g.childtypes = [get_childtypes(rule, alltypes) for rule ∈ g.rules]
+		g.bychildtypes = [BitVector([g.childtypes[i1] == g.childtypes[i2] for i2 ∈ 1:length(g.rules)]) for i1 ∈ 1:length(g.rules)]
 	end
 	for domain ∈ values(g.domains)
 		domain[idx] = 0

--- a/src/grammar_io.jl
+++ b/src/grammar_io.jl
@@ -60,7 +60,7 @@ function read_csg(grammarpath::AbstractString, constraintspath::OptionalPath=not
     end
 
     return ContextSensitiveGrammar(g.rules, g.types, g.isterminal, 
-        g.iseval, g.bytype, g.domains, g.childtypes, g.log_probabilities, constraints)
+        g.iseval, g.bytype, g.domains, g.childtypes, g.bychildtypes, g.log_probabilities, constraints)
 end
 
 """
@@ -93,7 +93,7 @@ function read_pcsg(grammarpath::AbstractString, constraintspath::OptionalPath=no
     end
     
     return ContextSensitiveGrammar(g.rules, g.types, g.isterminal, 
-        g.iseval, g.bytype, g.domains, g.childtypes, g.log_probabilities, constraints)
+        g.iseval, g.bytype, g.domains, g.childtypes, g.bychildtypes, g.log_probabilities, constraints)
 end
 
 

--- a/src/nodelocation.jl
+++ b/src/nodelocation.jl
@@ -5,8 +5,8 @@ swapped out.
 If i is 0 the node pointed to is the root node and parent is the node itself.
 """
 struct NodeLoc
-	parent::RuleNode
-	i::Int
+    parent::RuleNode
+    i::Int
 end
 
 """
@@ -20,12 +20,12 @@ get(root::RuleNode, loc::NodeLoc)
 Obtain the node pointed to by loc.
 """
 function Base.get(root::RuleNode, loc::NodeLoc)
-	parent, i = loc.parent, loc.i
-	if loc.i > 0
-		return parent.children[i]
-	else
-		return root
-	end
+    parent, i = loc.parent, loc.i
+    if loc.i > 0
+        return parent.children[i]
+    else
+        return root
+    end
 end
 
 
@@ -34,13 +34,13 @@ insert!(loc::NodeLoc, rulenode::RuleNode)
 Replaces the subtree pointed to by loc with the given rulenode.
 """
 function Base.insert!(root::RuleNode, loc::NodeLoc, rulenode::RuleNode)
-	parent, i = loc.parent, loc.i
-	if loc.i > 0
-		parent.children[i] = rulenode
-	else
-		root.ind = rulenode.ind
-		root._val = rulenode._val
-		root.children = rulenode.children
-	end
-	return root
+    parent, i = loc.parent, loc.i
+    if loc.i > 0
+        parent.children[i] = rulenode
+    else
+        root.ind = rulenode.ind
+        root._val = rulenode._val
+        root.children = rulenode.children
+    end
+    return root
 end

--- a/src/rulenode_operators.jl
+++ b/src/rulenode_operators.jl
@@ -1,6 +1,8 @@
 HerbCore.RuleNode(ind::Int, grammar::Grammar) = RuleNode(ind, nothing, [Hole(get_domain(grammar, type)) for type ∈ grammar.childtypes[ind]])
 HerbCore.RuleNode(ind::Int, _val::Any, grammar::Grammar) = RuleNode(ind, _val, [Hole(get_domain(grammar, type)) for type ∈ grammar.childtypes[ind]])
 
+HerbCore.FixedShapedHole(domain::BitVector, grammar::Grammar) = FixedShapedHole(domain, [Hole(get_domain(grammar, type)) for type ∈ grammar.childtypes[ind]])
+
 rulesoftype(::Hole, ::Set{Int}) = Set{Int}()
 
 """

--- a/src/rulenode_operators.jl
+++ b/src/rulenode_operators.jl
@@ -6,7 +6,7 @@ HerbCore.FixedShapedHole(domain::BitVector, grammar::AbstractGrammar) = FixedSha
 rulesoftype(::Hole, ::Set{Int}) = Set{Int}()
 
 """
-	rulesoftype(node::RuleNode, grammar::AbstractGrammar, ruletype::Symbol)
+    rulesoftype(node::RuleNode, grammar::AbstractGrammar, ruletype::Symbol)
 
 Returns every rule of nonterminal symbol `ruletype` that is also used in the [`AbstractRuleNode`](@ref) tree.
 """
@@ -15,138 +15,138 @@ rulesoftype(::Hole, ::AbstractGrammar, ::Symbol) = Set{Int}()
 
 
 """
-	rulesoftype(node::RuleNode, ruleset::Set{Int}, ignoreNode::RuleNode)
+    rulesoftype(node::RuleNode, ruleset::Set{Int}, ignoreNode::RuleNode)
 
 Returns every rule in the ruleset that is also used in the [`AbstractRuleNode`](@ref) tree, but not in the `ignoreNode` subtree.
 
 !!! warning
-	The `ignoreNode` must be a subtree of `node` for it to have an effect.
+    The `ignoreNode` must be a subtree of `node` for it to have an effect.
 """
 function rulesoftype(node::RuleNode, ruleset::Set{Int}, ignoreNode::RuleNode)
-	retval = Set()
+    retval = Set()
 
-	if node == ignoreNode
-		return retval
-	end
+    if node == ignoreNode
+        return retval
+    end
 
-	if node.ind ∈ ruleset
-		union!(retval, [node.ind])
-	end
+    if node.ind ∈ ruleset
+        union!(retval, [node.ind])
+    end
 
-	if isempty(node.children)
-		return retval
-	else
-		for child ∈ node.children
-			union!(retval, rulesoftype(child, ruleset))
-		end
+    if isempty(node.children)
+        return retval
+    else
+        for child ∈ node.children
+            union!(retval, rulesoftype(child, ruleset))
+        end
 
-		return retval
-	end
+        return retval
+    end
 end
 rulesoftype(node::RuleNode, ruleset::Set{Int}, ::Hole) = rulesoftype(node, ruleset)
 rulesoftype(::Hole, ::Set{Int}, ::RuleNode) = Set()
 rulesoftype(::Hole, ::Set{Int}, ::Hole) = Set()
 
 """
-	rulesoftype(node::RuleNode, grammar::AbstractGrammar, ruletype::Symbol, ignoreNode::RuleNode)
+    rulesoftype(node::RuleNode, grammar::AbstractGrammar, ruletype::Symbol, ignoreNode::RuleNode)
 
 Returns every rule of nonterminal symbol `ruletype` that is also used in the [`AbstractRuleNode`](@ref) tree, but not in the `ignoreNode` subtree.
 
 !!! warning
-	The `ignoreNode` must be a subtree of `node` for it to have an effect.
+    The `ignoreNode` must be a subtree of `node` for it to have an effect.
 """
 rulesoftype(node::RuleNode, grammar::AbstractGrammar, ruletype::Symbol, ignoreNode::RuleNode) = rulesoftype(node, Set(grammar[ruletype]), ignoreNode)
 rulesoftype(::Hole, ::AbstractGrammar, ::Symbol, ::RuleNode) = Set()
 
 """
-	swap_node(expr::AbstractRuleNode, new_expr::AbstractRuleNode, path::Vector{Int})
+    swap_node(expr::AbstractRuleNode, new_expr::AbstractRuleNode, path::Vector{Int})
 
 Replace a node in `expr`, specified by `path`, with `new_expr`.
 Path is a sequence of child indices, starting from the root node.
 """
 function swap_node(expr::AbstractRuleNode, new_expr::AbstractRuleNode, path::Vector{Int})
-	if length(path) == 1
-		expr.children[path[begin]] = new_expr
-	else
-		swap_node(expr.children[path[begin]], new_expr, path[2:end])
-	end
+    if length(path) == 1
+        expr.children[path[begin]] = new_expr
+    else
+        swap_node(expr.children[path[begin]], new_expr, path[2:end])
+    end
 end
 
 
 """
-	swap_node(expr::RuleNode, node::RuleNode, child_index::Int, new_expr::RuleNode)
+    swap_node(expr::RuleNode, node::RuleNode, child_index::Int, new_expr::RuleNode)
 
 Replace child `i` of a node, a part of larger `expr`, with `new_expr`.
 """
 function swap_node(expr::RuleNode, node::RuleNode, child_index::Int, new_expr::RuleNode)
-	if expr == node 
-		node.children[child_index] = new_expr
-	else
-		for child ∈ expr.children
-			swap_node(child, node, child_index, new_expr)
-		end
-	end
+    if expr == node 
+        node.children[child_index] = new_expr
+    else
+        for child ∈ expr.children
+            swap_node(child, node, child_index, new_expr)
+        end
+    end
 end
 
 
 """
-	get_rulesequence(node::RuleNode, path::Vector{Int})
+    get_rulesequence(node::RuleNode, path::Vector{Int})
 
 Extract the derivation sequence from a path (sequence of child indices) and an [`AbstractRuleNode`](@ref).
 If the path is deeper than the deepest node, it returns what it has.
 """
 function get_rulesequence(node::RuleNode, path::Vector{Int})
-	if node.ind == 0 # sign for empty node 
-		return Vector{Int}()
-	elseif isempty(node.children) # no children, nowhere to follow the path; still return the index
-		return [node.ind]
-	elseif isempty(path)
-		return [node.ind]
-	elseif isassigned(path, 2)
-		# at least two items are left in the path
-		# need to access the child with get because it can happen that the child is not yet built
-		return append!([node.ind], get_rulesequence(get(node.children, path[begin], RuleNode(0)), path[2:end]))
-	else
-		# if only one item left in the path
-		# need to access the child with get because it can happen that the child is not yet built
-		return append!([node.ind], get_rulesequence(get(node.children, path[begin], RuleNode(0)), Vector{Int}()))
-	end
+    if node.ind == 0 # sign for empty node 
+        return Vector{Int}()
+    elseif isempty(node.children) # no children, nowhere to follow the path; still return the index
+        return [node.ind]
+    elseif isempty(path)
+        return [node.ind]
+    elseif isassigned(path, 2)
+        # at least two items are left in the path
+        # need to access the child with get because it can happen that the child is not yet built
+        return append!([node.ind], get_rulesequence(get(node.children, path[begin], RuleNode(0)), path[2:end]))
+    else
+        # if only one item left in the path
+        # need to access the child with get because it can happen that the child is not yet built
+        return append!([node.ind], get_rulesequence(get(node.children, path[begin], RuleNode(0)), Vector{Int}()))
+    end
 end
 
 get_rulesequence(::Hole, ::Vector{Int}) = Vector{Int}()
 
 """
-	rulesonleft(expr::RuleNode, path::Vector{Int})::Set{Int}
+    rulesonleft(expr::RuleNode, path::Vector{Int})::Set{Int}
 
 Finds all rules that are used in the left subtree defined by the path.
 """
 function rulesonleft(expr::RuleNode, path::Vector{Int})::Set{Int}
-	if isempty(expr.children)
-		# if the encountered node is terminal or non-expanded non-terminal, return node id
-		Set{Int}(expr.ind)
-	elseif isempty(path)
-		# if path is empty, collect the entire subtree
-		ruleset = Set{Int}(expr.ind)
-		for ch in expr.children
-			union!(ruleset, rulesonleft(ch, Vector{Int}()))
-		end
-		return ruleset 
-	elseif length(path) == 1
-		# if there is only one element left in the path, collect all children except the one indicated in the path
-		ruleset = Set{Int}(expr.ind)
-		for i in 1:path[begin]-1
-			union!(ruleset, rulesonleft(expr.children[i], Vector{Int}()))
-		end
-		return ruleset 
-	else
-		# collect all subtrees up to the child indexed in the path
-		ruleset = Set{Int}(expr.ind)
-		for i in 1:path[begin]-1
-			union!(ruleset, rulesonleft(expr.children[i], Vector{Int}()))
-		end
-		union!(ruleset, rulesonleft(expr.children[path[begin]], path[2:end]))
-		return ruleset 
-	end
+    if isempty(expr.children)
+        # if the encountered node is terminal or non-expanded non-terminal, return node id
+        Set{Int}(expr.ind)
+    elseif isempty(path)
+        # if path is empty, collect the entire subtree
+        ruleset = Set{Int}(expr.ind)
+        for ch in expr.children
+            union!(ruleset, rulesonleft(ch, Vector{Int}()))
+        end
+        return ruleset 
+    elseif length(path) == 1
+        # if there is only one element left in the path, collect all children except the one indicated in the path
+        ruleset = Set{Int}(expr.ind)
+        for i in 1:path[begin]-1
+            union!(ruleset, rulesonleft(expr.children[i], Vector{Int}()))
+        end
+        return ruleset 
+    else
+        # collect all subtrees up to the child indexed in the path
+        ruleset = Set{Int}(expr.ind)
+        for i in 1:path[begin]-1
+            union!(ruleset, rulesonleft(expr.children[i], Vector{Int}()))
+        end
+        union!(ruleset, rulesonleft(expr.children[path[begin]], path[2:end]))
+        return ruleset 
+    end
 end
 
 rulesonleft(::Hole, ::Vector{Int}) = Set{Int}()
@@ -175,18 +175,18 @@ rulesonleft(::Hole, ::Vector{Int}) = Set{Int}()
 
 
 """
-	rulenode2expr(rulenode::RuleNode, grammar::AbstractGrammar)
+    rulenode2expr(rulenode::RuleNode, grammar::AbstractGrammar)
 
 Converts a [`RuleNode`](@ref) into a Julia expression corresponding to the rule definitions in the grammar.
 The returned expression can be evaluated with Julia semantics using `eval()`.
 """
 function rulenode2expr(rulenode::RuleNode, grammar::AbstractGrammar)
-	root = (rulenode._val !== nothing) ?
-		rulenode._val : deepcopy(grammar.rules[rulenode.ind])
-	if !grammar.isterminal[rulenode.ind] # not terminal
-		root,_ = _rulenode2expr(root, rulenode, grammar)
-	end
-	return root
+    root = (rulenode._val !== nothing) ?
+        rulenode._val : deepcopy(grammar.rules[rulenode.ind])
+    if !grammar.isterminal[rulenode.ind] # not terminal
+        root,_ = _rulenode2expr(root, rulenode, grammar)
+    end
+    return root
 end
 
 
@@ -198,40 +198,40 @@ end
 rulenode2expr(rulenode::Hole, grammar::AbstractGrammar) = _rulenode2expr(rulenode::Hole, grammar::AbstractGrammar)
 
 function _rulenode2expr(expr::Expr, rulenode::RuleNode, grammar::AbstractGrammar, j=0)
-	for (k,arg) in enumerate(expr.args)
-		if isa(arg, Expr)
-			expr.args[k],j = _rulenode2expr(arg, rulenode, grammar, j)
-		elseif haskey(grammar.bytype, arg)
-			child = rulenode.children[j+=1]
-			if isa(child, Hole)
+    for (k,arg) in enumerate(expr.args)
+        if isa(arg, Expr)
+            expr.args[k],j = _rulenode2expr(arg, rulenode, grammar, j)
+        elseif haskey(grammar.bytype, arg)
+            child = rulenode.children[j+=1]
+            if isa(child, Hole)
         expr.args[k] = _rulenode2expr(child, grammar)
-		    continue
-			end
-			expr.args[k] = (child._val !== nothing) ?
-				child._val : deepcopy(grammar.rules[child.ind])
-			if !isterminal(grammar, child)
-				expr.args[k],_ = _rulenode2expr(expr.args[k], child, grammar, 0)
-			end
-		end
-	end
-	return expr, j
+            continue
+            end
+            expr.args[k] = (child._val !== nothing) ?
+                child._val : deepcopy(grammar.rules[child.ind])
+            if !isterminal(grammar, child)
+                expr.args[k],_ = _rulenode2expr(expr.args[k], child, grammar, 0)
+            end
+        end
+    end
+    return expr, j
 end
 
 
 function _rulenode2expr(typ::Symbol, rulenode::RuleNode, grammar::AbstractGrammar, j=0)
-	retval = typ
-		if haskey(grammar.bytype, typ)
-			child = rulenode.children[1]
+    retval = typ
+        if haskey(grammar.bytype, typ)
+            child = rulenode.children[1]
       if isa(child, Hole) 
           return retval, j
       end
-			retval = (child._val !== nothing) ?
-				child._val : deepcopy(grammar.rules[child.ind])
-			if !grammar.isterminal[child.ind]
-				retval,_ = _rulenode2expr(retval, child, grammar, 0)
-			end
-		end
-	retval, j
+            retval = (child._val !== nothing) ?
+                child._val : deepcopy(grammar.rules[child.ind])
+            if !grammar.isterminal[child.ind]
+                retval,_ = _rulenode2expr(retval, child, grammar, 0)
+            end
+        end
+    retval, j
 end
 
 
@@ -239,34 +239,34 @@ end
 Calculates the log probability associated with a rulenode in a probabilistic grammar.
 """
 function rulenode_log_probability(node::RuleNode, grammar::AbstractGrammar)
-	log_probability(grammar, node.ind) + sum((rulenode_log_probability(c, grammar) for c ∈ node.children), init=1)
+    log_probability(grammar, node.ind) + sum((rulenode_log_probability(c, grammar) for c ∈ node.children), init=1)
 end
 
 rulenode_log_probability(::Hole, ::AbstractGrammar) = 1
 
 
 """
-	iscomplete(grammar::AbstractGrammar, node::RuleNode) 
+    iscomplete(grammar::AbstractGrammar, node::RuleNode) 
 
 Returns true if the expression represented by the [`RuleNode`](@ref) is a complete expression, 
 meaning that it is fully defined and doesn't have any [`Hole`](@ref)s.
 """
 function iscomplete(grammar::AbstractGrammar, node::RuleNode) 
-	if isterminal(grammar, node)
-		return true
-	elseif isempty(node.children)
-		# if not terminal but has children
-		return false
-	else
-		return all([iscomplete(grammar, c) for c in node.children])
-	end
+    if isterminal(grammar, node)
+        return true
+    elseif isempty(node.children)
+        # if not terminal but has children
+        return false
+    else
+        return all([iscomplete(grammar, c) for c in node.children])
+    end
 end
 
 iscomplete(grammar::AbstractGrammar, ::Hole) = false
 
 
 """
-	return_type(grammar::AbstractGrammar, node::RuleNode)
+    return_type(grammar::AbstractGrammar, node::RuleNode)
 
 Gives the return type or nonterminal symbol in the production rule used by `node`.
 """
@@ -274,7 +274,7 @@ return_type(grammar::AbstractGrammar, node::RuleNode)::Symbol = grammar.types[no
 
 
 """
-	child_types(grammar::AbstractGrammar, node::RuleNode)
+    child_types(grammar::AbstractGrammar, node::RuleNode)
 
 Returns the list of child types (nonterminal symbols) in the production rule used by `node`.
 """
@@ -282,7 +282,7 @@ child_types(grammar::AbstractGrammar, node::RuleNode)::Vector{Symbol} = grammar.
 
 
 """
-	isterminal(grammar::AbstractGrammar, node::RuleNode)::Bool
+    isterminal(grammar::AbstractGrammar, node::RuleNode)::Bool
 
 Returns true if the production rule used by `node` is terminal, i.e., does not contain any nonterminal symbols.
 """
@@ -290,14 +290,14 @@ isterminal(grammar::AbstractGrammar, node::RuleNode)::Bool = grammar.isterminal[
 
 
 """
-	nchildren(grammar::AbstractGrammar, node::RuleNode)::Int
+    nchildren(grammar::AbstractGrammar, node::RuleNode)::Int
 
 Returns the number of children in the production rule used by `node`.
 """
 nchildren(grammar::AbstractGrammar, node::RuleNode)::Int = length(child_types(grammar, node))
 
 """
-	isvariable(grammar::AbstractGrammar, node::RuleNode)::Bool
+    isvariable(grammar::AbstractGrammar, node::RuleNode)::Bool
 
 Return true if the rule used by `node` represents a variable in a program (essentially, an input to the program)
 """
@@ -307,43 +307,43 @@ isvariable(grammar::AbstractGrammar, node::RuleNode)::Bool = (
     !_is_defined_in_modules(grammar.rules[node.ind], [Main, Base])
 )
 """
-	isvariable(grammar::AbstractGrammar, node::RuleNode, mod::Module)::Bool
+    isvariable(grammar::AbstractGrammar, node::RuleNode, mod::Module)::Bool
 
 Return true if the rule used by `node` represents a variable.
-	
+    
 Taking into account the symbols defined in the given module(s).
 """
 isvariable(grammar::AbstractGrammar, node::RuleNode, mod::Module...)::Bool = (
-	grammar.isterminal[node.ind] &&
-	grammar.rules[node.ind] isa Symbol &&
-	!_is_defined_in_modules(grammar.rules[node.ind], [mod..., Main, Base])
+    grammar.isterminal[node.ind] &&
+    grammar.rules[node.ind] isa Symbol &&
+    !_is_defined_in_modules(grammar.rules[node.ind], [mod..., Main, Base])
 )
 
 """
-	isvariable(grammar::AbstractGrammar, ind::Int)::Bool
+    isvariable(grammar::AbstractGrammar, ind::Int)::Bool
 
 Return true if the rule with index `ind` represents a variable.
 """
 isvariable(grammar::AbstractGrammar, ind::Int)::Bool = (
-	grammar.isterminal[ind] &&
-	grammar.rules[ind] isa Symbol &&
-	!_is_defined_in_modules(grammar.rules[ind], [Main, Base])
+    grammar.isterminal[ind] &&
+    grammar.rules[ind] isa Symbol &&
+    !_is_defined_in_modules(grammar.rules[ind], [Main, Base])
 )
 """
-	isvariable(grammar::AbstractGrammar, ind::Int, mod::Module)::Bool
+    isvariable(grammar::AbstractGrammar, ind::Int, mod::Module)::Bool
 
 Return true if the rule with index `ind` represents a variable.
-	
+    
 Taking into account the symbols defined in the given module(s).
 """
 isvariable(grammar::AbstractGrammar, ind::Int, mod::Module...)::Bool = (
-	grammar.isterminal[ind] &&
-	grammar.rules[ind] isa Symbol &&
-	!_is_defined_in_modules(grammar.rules[ind], [mod..., Main, Base])
+    grammar.isterminal[ind] &&
+    grammar.rules[ind] isa Symbol &&
+    !_is_defined_in_modules(grammar.rules[ind], [mod..., Main, Base])
 )
 
 """
-	contains_returntype(node::RuleNode, grammar::AbstractGrammar, sym::Symbol, maxdepth::Int=typemax(Int))
+    contains_returntype(node::RuleNode, grammar::AbstractGrammar, sym::Symbol, maxdepth::Int=typemax(Int))
 
 Returns true if the tree rooted at `node` contains at least one node at depth less than `maxdepth`
 with the given return type or nonterminal symbol.
@@ -362,10 +362,10 @@ function contains_returntype(node::RuleNode, grammar::AbstractGrammar, sym::Symb
 end
 
 function Base.display(rulenode::RuleNode, grammar::AbstractGrammar)
-	root = rulenode2expr(rulenode, grammar)
-	if isa(root, Expr)
-	    walk_tree(root)
-	else
-	    root
-	end
+    root = rulenode2expr(rulenode, grammar)
+    if isa(root, Expr)
+        walk_tree(root)
+    else
+        root
+    end
 end

--- a/src/rulenode_operators.jl
+++ b/src/rulenode_operators.jl
@@ -1,7 +1,7 @@
 HerbCore.RuleNode(ind::Int, grammar::Grammar) = RuleNode(ind, nothing, [Hole(get_domain(grammar, type)) for type ∈ grammar.childtypes[ind]])
 HerbCore.RuleNode(ind::Int, _val::Any, grammar::Grammar) = RuleNode(ind, _val, [Hole(get_domain(grammar, type)) for type ∈ grammar.childtypes[ind]])
 
-HerbCore.FixedShapedHole(domain::BitVector, grammar::Grammar) = FixedShapedHole(domain, [Hole(get_domain(grammar, type)) for type ∈ grammar.childtypes[ind]])
+HerbCore.FixedShapedHole(domain::BitVector, grammar::Grammar) = FixedShapedHole(domain, [Hole(get_domain(grammar, type)) for type ∈ grammar.childtypes[findfirst(domain)]])
 
 rulesoftype(::Hole, ::Set{Int}) = Set{Int}()
 

--- a/src/rulenode_operators.jl
+++ b/src/rulenode_operators.jl
@@ -152,25 +152,26 @@ end
 rulesonleft(::Hole, ::Vector{Int}) = Set{Int}()
 
 
-"""
-	get_node_at_location(root::RuleNode, location::Vector{Int})
+#TODO: it seems like this function is exactly redefining what is already in HerbCore/rulenode.jl. It can be safely deleted
+# """
+# 	get_node_at_location(root::RuleNode, location::Vector{Int})
 
-Retrieves a [`RuleNode`](@ref) at the given location by reference. 
-"""
-function get_node_at_location(root::RuleNode, location::Vector{Int})
-    if location == []
-        return root
-    else
-        return get_node_at_location(root.children[location[1]], location[2:end])
-    end
-end
+# Retrieves a [`RuleNode`](@ref) at the given location by reference. 
+# """
+# function get_node_at_location(root::AbstractRuleNode, location::Vector{Int})
+#     if location == []
+#         return root
+#     else
+#         return get_node_at_location(root.children[location[1]], location[2:end])
+#     end
+# end
 
-function get_node_at_location(root::Hole, location::Vector{Int})
-    if location == []
-        return root
-    end
-    return nothing
-end
+# function get_node_at_location(root::VariableShapedHole, location::Vector{Int})
+#     if location == []
+#         return root
+#     end
+#     return nothing
+# end
 
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -4,13 +4,13 @@ AbstractTrees.printnode(io::IO, node::RuleNode) = print(io, node.ind)
 
 
 """
-    mindepth_map(grammar::Grammar)
+    mindepth_map(grammar::AbstractGrammar)
 
-Returns the minimum depth achievable for each production rule in the [`Grammar`](@ref).
+Returns the minimum depth achievable for each production rule in the [`AbstractGrammar`](@ref).
 In other words, this function finds the depths of the lowest trees that can be made 
 using each of the available production rules as a root.
 """
-function mindepth_map(grammar::Grammar)
+function mindepth_map(grammar::AbstractGrammar)
     dmap0 = Int[isterminal(grammar,i) ? 1 : typemax(Int)/2 for i in eachindex(grammar.rules)]
     dmap1 = fill(-1, length(grammar.rules)) 
     while dmap0 != dmap1
@@ -23,37 +23,37 @@ function mindepth_map(grammar::Grammar)
 end
 
 
-function _mindepth(grammar::Grammar, rule_index::Int, dmap::AbstractVector{Int})
+function _mindepth(grammar::AbstractGrammar, rule_index::Int, dmap::AbstractVector{Int})
     isterminal(grammar, rule_index) && return 1
     return 1 + maximum([mindepth(grammar, ctyp, dmap) for ctyp in child_types(grammar, rule_index)])
 end
 
 
 """
-    mindepth(grammar::Grammar, typ::Symbol, dmap::AbstractVector{Int})
+    mindepth(grammar::AbstractGrammar, typ::Symbol, dmap::AbstractVector{Int})
 
 Returns the minimum depth achievable for a given nonterminal symbol.
 The minimum depth is the depth of the lowest tree that can be made using `typ` 
 as a start symbol. `dmap` can be obtained from [`mindepth_map`](@ref).
 """
-function mindepth(grammar::Grammar, typ::Symbol, dmap::AbstractVector{Int})
+function mindepth(grammar::AbstractGrammar, typ::Symbol, dmap::AbstractVector{Int})
     return minimum(dmap[grammar.bytype[typ]])
 end
 
 """
     SymbolTable
 
-Data structure for mapping terminal symbols in the [`Grammar`](@ref) to their Julia interpretation.
+Data structure for mapping terminal symbols in the [`AbstractGrammar`](@ref) to their Julia interpretation.
 """
 const SymbolTable = Dict{Symbol,Any}
 
 """
-    SymbolTable(grammar::Grammar, mod::Module=Main)
+    SymbolTable(grammar::AbstractGrammar, mod::Module=Main)
 
 Returns a [`SymbolTable`](@ref) populated with a mapping from symbols in the 
-[`Grammar`](@ref) to symbols in module `mod` or `Main`, if defined.
+[`AbstractGrammar`](@ref) to symbols in module `mod` or `Main`, if defined.
 """
-function HerbGrammar.SymbolTable(grammar::Grammar, mod::Module=Main)
+function HerbGrammar.SymbolTable(grammar::AbstractGrammar, mod::Module=Main)
     tab = SymbolTable()
     for rule in grammar.rules
         _add_to_symboltable!(tab, rule, mod)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -105,19 +105,19 @@ end
 Checks if elements of `vec1` are contained in `vec2` in the same order (possibly with elements in between)
 """
 function containedin(vec1::Vector, vec2::Vector)
-	max_elements = length(vec1)
-	vec1_index = 1 # keeps track where we are in the first vector
-	for item in vec2
-		if vec1_index > max_elements
-			return true
-		end
-		
-		if item == vec1[vec1_index]
-			vec1_index += 1  # increase the index every time we encounter the matching element
-		end
-	end
+    max_elements = length(vec1)
+    vec1_index = 1 # keeps track where we are in the first vector
+    for item in vec2
+        if vec1_index > max_elements
+            return true
+        end
+        
+        if item == vec1[vec1_index]
+            vec1_index += 1  # increase the index every time we encounter the matching element
+        end
+    end
 
-	return vec1_index > max_elements
+    return vec1_index > max_elements
 end
 
 

--- a/test/test_csg.jl
+++ b/test/test_csg.jl
@@ -173,4 +173,35 @@
         @test all(g₁.rules .== [:x, :(R + R), true, 1, 2])
     end
 
+    @testset "Test bychildtypes" begin
+        g = @csgrammar begin
+            S = 1
+            S = 2 + S + A
+            S = 3 + A + S
+            A = 4
+            S = 5 + S + S
+            S = 6 + S + S
+            S = 7 + S
+            A = 8 + S
+        end
+        
+        @test g.childtypes[1] == []
+        @test g.childtypes[2] == [:S, :A]
+        @test g.childtypes[3] == [:A, :S]
+        @test g.childtypes[4] == []
+        @test g.childtypes[5] == [:S, :S]
+        @test g.childtypes[6] == [:S, :S]
+        @test g.childtypes[7] == [:S]
+        @test g.childtypes[8] == [:S]
+        
+        @test g.bychildtypes[1] == [1, 0, 0, 1, 0, 0, 0, 0] # 1, 4
+        @test g.bychildtypes[2] == [0, 1, 0, 0, 0, 0, 0, 0] # 2
+        @test g.bychildtypes[3] == [0, 0, 1, 0, 0, 0, 0, 0] # 3
+        @test g.bychildtypes[4] == [1, 0, 0, 1, 0, 0, 0, 0] # 1, 4
+        @test g.bychildtypes[5] == [0, 0, 0, 0, 1, 1, 0, 0] # 5, 6
+        @test g.bychildtypes[6] == [0, 0, 0, 0, 1, 1, 0, 0] # 5, 6
+        @test g.bychildtypes[7] == [0, 0, 0, 0, 0, 0, 1, 1] # 7, 8
+        @test g.bychildtypes[8] == [0, 0, 0, 0, 0, 0, 1, 1] # 7, 8
+    end
+
 end


### PR DESCRIPTION
Large PR involving 4 repositories:
- `HerbSearch` @solver
- `HerbConstraints` @solver
- `HerbCore` @holes-types
- `HerbGrammar` @holes-types (small changes)

On these respective branches, I am worked on two new major components:
1. A constraint propagation solver
2. New hole types

1. I am replacing `propagate_constraints` with a new constraint `Solver` struct. The goal is to increase the inference of constraint propagators while reducing the number of propagations needed. Currently constraint solving is integrated in the top down iterator, but the new solver should also be compatible with any type of program iterator. This means that all program iterators should be rewritten to be compatible with the constraint solver. The idea is that iterators must manipulate program trees through the solver’s API so the propagation of the constraints can happen under the hood. For example:

```julia
"""
    substitute!(solver::Solver, path::Vector{Int}, new_node::AbstractRuleNode)

Substitute the node at the `path`, with a `new_node`
"""
function substitute!(solver::Solver, path::Vector{Int}, new_node::AbstractRuleNode)
    #...
end
```

```julia
"""
    fill_hole!(solver::Solver, path::Vector{Int}, rule_index::Int)

Fill in the hole located at the `path` with rule `rule_index`.
It is assumed the path points to a hole, otherwise an exception will be thrown.
It is assumed rule_index ∈ hole.domain, otherwise an exception will be thrown.
"""
function fill_hole!(solver::Solver, path::Vector{Int}, rule_index::Int)
    #...
end
```

2. The `Hole` struct will be split up into two new concrete hole structs: `FixedShapedHole` and `VariableShapedHole`. The main difference between these two structs is that the domain of a fixed shaped hole contains only rules of exactly the same child types (e.g. `A -> A + B` and `A -> A * B` have the same childtypes. `A -> A + A` has different childtypes). The advantage of fixed shaped holes is that child nodes can already be instantiated before the concrete rule of the parent is known. This reduces the amount of trees that need to be stored in memory and can be exploited for stronger inference during constraint propagation.
