### PR TITLE
Duplicate constraints

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HerbGrammar"
 uuid = "4ef9e186-2fe5-4b24-8de7-9f7291f24af7"
 authors = ["Sebastijan Dumancic <s.dumancic@tudelft.nl>", "Jaap de Jong <J.deJong-18@student.tudelft.nl>", "Nicolae Filat <N.Filat@student.tudelft.nl>", "Piotr Cichoń <gitlab@gitlab.ewi.tudelft.nl>"]
-version = "0.6.1"
+version = "0.6.2"
 
 [deps]
 HerbCore = "2b23ba43-8213-43cb-b5ea-38c12b45bd45"

--- a/src/csg/csg.jl
+++ b/src/csg/csg.jl
@@ -172,14 +172,20 @@ end
 """
 	addconstraint!(grammar::ContextSensitiveGrammar, c::AbstractConstraint)
 
-Adds a [`AbstractConstraint`](@ref) to a [`ContextSensitiveGrammar`](@ref). Errors if constraint's domain is not valid.
+Adds a [`AbstractConstraint`](@ref) to a [`ContextSensitiveGrammar`](@ref). 
+
+!!! warning
+    - Errors if the constraint's domain is invalid.
+    - Calls to this function are ignored if the constraint already exists in the grammar.
 """
 function addconstraint!(grammar::ContextSensitiveGrammar, c::AbstractConstraint)
     if !HerbCore.is_domain_valid(c, grammar)
         error("The domain of $(typeof(c)) is not valid for the provided grammar. Rule index or domain size does not match the number of grammar rule: $(length(grammar.rules))")
 
     end
-    push!(grammar.constraints, c)
+    if isempty(grammar.constraints) || !any(x -> HerbCore.issame(x, c), grammar.constraints) # only add constraint if it doesn't exist yet
+        push!(grammar.constraints, c)
+    end
     # Note: Tests for adding constraints to a grammar can be found in HerbConstraints.
 end
 


### PR DESCRIPTION
## Changes

`addconstraint!`: Only adds a constraint to grammar if no duplicate constraint is found.

## Issues
Partly addresses #116.

