### PR TITLE
Remove extraneous prints in `expr2rulenode`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HerbGrammar"
 uuid = "4ef9e186-2fe5-4b24-8de7-9f7291f24af7"
 authors = ["Sebastijan Dumancic <s.dumancic@tudelft.nl>", "Jaap de Jong <J.deJong-18@student.tudelft.nl>", "Nicolae Filat <N.Filat@student.tudelft.nl>", "Piotr Cichoń <gitlab@gitlab.ewi.tudelft.nl>"]
-version = "1.1.1"
+version = "1.1.2"
 
 [deps]
 HerbCore = "2b23ba43-8213-43cb-b5ea-38c12b45bd45"

--- a/src/rulenode_operators.jl
+++ b/src/rulenode_operators.jl
@@ -169,9 +169,7 @@ end
 function _expr2rulenode(expr::Expr, grammar::AbstractGrammar, tags::AbstractDict)
     if expr.head == :call
         if !haskey(tags, expr)
-            @info expr.args
             parameters = [_expr2rulenode(expr.args[i], grammar, tags) for i in (2:length(expr.args))]
-            @info parameters
             pl = map(x -> x[1], parameters)
             pr = map(x -> x[2], parameters)
 


### PR DESCRIPTION
Accidentally left some print statements in from debugging in https://github.com/Herb-AI/HerbGrammar.jl/pull/128. This PR removes them.

~I added a `[workspace]` section to the `Project.toml` and adds `HerbGrammar` explicitly as a test dependency to its own tests (this is preferred by `Pkg` now: https://pkgdocs.julialang.org/v1/creating-packages/#Info-bdf8c55dbaff5c4c)~ ➡️ #133