### PR TITLE
chore: add `[workspace]`, update test deps.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,9 @@ uuid = "4ef9e186-2fe5-4b24-8de7-9f7291f24af7"
 authors = ["Sebastijan Dumancic <s.dumancic@tudelft.nl>", "Jaap de Jong <J.deJong-18@student.tudelft.nl>", "Nicolae Filat <N.Filat@student.tudelft.nl>", "Piotr Cichoń <gitlab@gitlab.ewi.tudelft.nl>"]
 version = "1.1.1"
 
+[workspace]
+projects = ["test"]
+
 [deps]
 HerbCore = "2b23ba43-8213-43cb-b5ea-38c12b45bd45"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,5 +2,6 @@
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 HerbConstraints = "1fa96474-3206-4513-b4fa-23913f296dfc"
 HerbCore = "2b23ba43-8213-43cb-b5ea-38c12b45bd45"
+HerbGrammar = "4ef9e186-2fe5-4b24-8de7-9f7291f24af7"
 ReTestItems = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
The `[workspace]` section in `Project.toml` allows for projects to all resolve using a single `Manifest.toml`, meaning `test/Project.toml` will share the same environment as the base `Project.toml`. This allows you to explicitly add `HerbGrammar` as a test dependency in its own test project, bypassing the need for tools like `TestEnv`. `julia --project=test` gives you access to all test dependencies _and_ the `dev`'d version of `HerbGrammar`.

This is now the preferred way to structure projects according to `Pkg.jl`'s documentation: https://pkgdocs.julialang.org/v1/creating-packages/#Info-bdf8c55dbaff5c4c