### PR TITLE
Fixing issues with expr2rulenode

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HerbGrammar"
 uuid = "4ef9e186-2fe5-4b24-8de7-9f7291f24af7"
 authors = ["Sebastijan Dumancic <s.dumancic@tudelft.nl>", "Jaap de Jong <J.deJong-18@student.tudelft.nl>", "Nicolae Filat <N.Filat@student.tudelft.nl>", "Piotr Cichoń <gitlab@gitlab.ewi.tudelft.nl>"]
-version = "1.1.2"
+version = "1.1.3"
 
 [deps]
 HerbCore = "2b23ba43-8213-43cb-b5ea-38c12b45bd45"

--- a/src/rulenode_operators.jl
+++ b/src/rulenode_operators.jl
@@ -166,43 +166,87 @@ function grammar_map_right_to_left(grammar::AbstractGrammar)
     return tags
 end
 
+"""
+If the path from `source_type` to `target_type` within the grammar goes through multiple rules - recursively wrap them.
+"""
+function _wrap_rulenode_as(
+    target_type::Symbol, 
+    source_type::Symbol, 
+    node::RuleNode, 
+    grammar::AbstractGrammar, 
+    visited=Set{Symbol}()
+    )
+    if source_type == target_type
+        return node
+    elseif source_type in visited
+        return nothing
+    end
+
+    push!(visited, source_type)
+
+    for rule_idx in findall(==(source_type), grammar.rules)
+        wrapped_node = RuleNode(rule_idx, [node])
+        wrapped_type = grammar.types[rule_idx]
+        promoted = _wrap_rulenode_as(target_type, wrapped_type, wrapped_node, grammar, copy(visited))
+        if !isnothing(promoted)
+            return promoted
+        end
+    end
+
+    return nothing
+end
+
+"""
+Constructs a RuleNode matching expression 
+"""
+function _match_expr_rule(expr::Expr, parameters, grammar::AbstractGrammar)
+    expected_arity = length(parameters)
+
+    for (rule_idx, candidate) in pairs(grammar.rules)
+        # filter out rules that are not expressions
+        candidate isa Expr || continue
+        
+        # match the operation
+        expected_types = if expr.head == :call
+            # if it is a call - ensure that the operation matches.
+            candidate.args[1] == expr.args[1] || continue
+            candidate.args[2:end]
+        else
+            candidate.args
+        end
+        
+        # match arity
+        length(expected_types) == expected_arity || continue
+
+        children = RuleNode[]
+        matched = true
+
+        for ((source_type, child_node), expected_type) in zip(parameters, expected_types)
+            # the path from child type to the matched type might go through multiple intermediate nodes 
+            # wrap the child RuleNode
+            wrapped_child = _wrap_rulenode_as(expected_type, source_type, child_node, grammar)
+            if isnothing(wrapped_child)
+                # if wrapping failed - error later.
+                matched = false
+                break
+            end
+            push!(children, wrapped_child)
+        end
+
+        if matched
+            return (grammar.types[rule_idx], RuleNode(rule_idx, children))
+        end
+    end
+
+    error("Expression $(expr) cannot be represented in the grammar")
+end
+
 function _expr2rulenode(expr::Expr, grammar::AbstractGrammar, tags::AbstractDict)
     if expr.head == :call
         if !haskey(tags, expr)
-            parameters = [_expr2rulenode(expr.args[i], grammar, tags) for i in (2:length(expr.args))]
-            pl = map(x -> x[1], parameters)
-            pr = map(x -> x[2], parameters)
-
-            temp = [expr.args[1]; pl]
-            newexpr = Expr(:call, temp...)
-            rule = findfirst(==(newexpr), grammar.rules)
-
-
-            oldpl = copy(pl)
-            oldpr = copy(pr)
-            pnr = length(pl)
-
-            while isnothing(rule)
-
-                updatedrule = findfirst(==(pl[pnr]), grammar.rules)
-
-                if isnothing(updatedrule)
-                    pl[pnr] = oldpl[pnr]
-                    pr[pnr] = oldpr[pnr]
-                    pnr = pnr - 1
-                    continue
-                end
-
-                pl[pnr] = tags[pl[pnr]]
-                pr[pnr] = RuleNode(updatedrule, [pr[pnr]])
-
-                temp = [expr.args[1]; pl]
-                newexpr = Expr(:call, temp...)
-                rule = findfirst(==(newexpr), grammar.rules)
-
-                pnr = length(pl)
-            end
-            return (tags[newexpr], RuleNode(rule, pr))
+            # the expression may have some intermediate rules RuleNode representation -> need to search for the match
+            parameters = [_expr2rulenode(expr.args[i], grammar, tags) for i in 2:length(expr.args)]
+            return _match_expr_rule(expr, parameters, grammar)
         else
             rule = findfirst(==(expr), grammar.rules)
             return (tags[expr], RuleNode(rule, []))
@@ -210,41 +254,7 @@ function _expr2rulenode(expr::Expr, grammar::AbstractGrammar, tags::AbstractDict
     elseif expr.head == :block
         (l1, r1) = _expr2rulenode(expr.args[1], grammar, tags)
         (l2, r2) = _expr2rulenode(expr.args[3], grammar, tags)
-
-        temp = (l1, l2)
-
-        newexpr = Expr(:block, temp...)
-        rule = findfirst(==(newexpr), grammar.rules)
-
-        pl = [l1, l2]
-        pr = [r1, r2]
-
-        oldpl = copy(pl)
-        oldpr = copy(pr)
-        pnr = length(pl)
-
-        while isnothing(rule)
-
-            updatedrule = findfirst(==(pl[pnr]), grammar.rules)
-
-            if isnothing(updatedrule)
-                pl[pnr] = oldpl[pnr]
-                pr[pnr] = oldpr[pnr]
-                pnr = pnr - 1
-                continue
-            end
-
-            pl[pnr] = tags[pl[pnr]]
-            pr[pnr] = RuleNode(updatedrule, [pr[pnr]])
-
-            temp = (pl[1], pl[2])
-            newexpr = Expr(:block, temp...)
-            rule = findfirst(==(newexpr), grammar.rules)
-
-            pnr = length(pl)
-        end
-        return (tags[newexpr], RuleNode(rule, pr))
-
+        return _match_expr_rule(expr, [(l1, r1), (l2, r2)], grammar)
     elseif expr.head == :quote
         return _expr2rulenode(expr.args[1], grammar, tags)
     else
@@ -303,7 +313,7 @@ Converts an expression into a [`AbstractRuleNode`](@ref) corresponding to the ru
 """
 function expr2rulenode(expr::Symbol, grammar::AbstractGrammar, startSymbol::Symbol)
     tags = grammar_map_right_to_left(grammar)
-    (s, rn) = expr2rulenode(expr, grammar, tags)
+    (s, rn) = _expr2rulenode(expr, grammar, tags)
     while s != startSymbol
 
         updatedrule = findfirst(==(s), grammar.rules)

--- a/test/expr2rulenode_tests.jl
+++ b/test/expr2rulenode_tests.jl
@@ -103,3 +103,42 @@ end
     end
     @test expr2rulenode(:(at_cvc(_arg_1, 1)), grammar_11440431) == @rulenode 9{2,13}
 end
+
+
+@testitem "convert expr with multiple intermediate rules and multiple same types on rhs." begin
+    using HerbCore: @rulenode
+    @testset "Multiple similar types on RHS" begin
+    g = @csgrammar begin
+            S = A - B
+            S = A + B
+            S = f(A, B)
+            A = V
+            B = V
+            V = 1
+            V = 2
+        end
+        e1 = :(1-1)
+        @test expr2rulenode(e1, g) == @rulenode 1{4{6}, 5{6}}
+        @test rulenode2expr(expr2rulenode(e1, g), g) == e1
+        e2 = :(1+1)
+        @test expr2rulenode(e2, g) == @rulenode 2{4{6}, 5{6}}
+        @test rulenode2expr(expr2rulenode(e2, g), g) == e2
+        e3 = :(f(1, 1))
+        @test expr2rulenode(e3, g) == @rulenode 3{4{6}, 5{6}}
+        @test rulenode2expr(expr2rulenode(e3, g), g) == e3
+
+        @test_throws ErrorException expr2rulenode(:((1 + 1) + 1), g)
+    end
+    @testset "Nested types" begin
+        g = @csgrammar begin
+            S = A - D
+            A = B
+            B = C
+            C = 1
+            D = 3
+        end
+        @test expr2rulenode(:(1-3), g) == @rulenode 1{2{3{4}}, 5}
+        @test rulenode2expr(expr2rulenode(:((1)-3), g), g) == :(1 - 3)
+    end
+
+end


### PR DESCRIPTION
Previously conversion could break when a child RuleNode could be applied through multiple intermediate terminals due to weak expression-to-rule matching.

```
           g = @csgrammar S = A - B
            A = V
            B = V
            V = 1
            end
            expr2rulenode(:(1-1), g)
 ```
 The above would fail (extended example in the tests)
 
This fix addresses the issue.