### PR TITLE
feat: add `normalize` parameter to prob. `add_rule!`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HerbGrammar"
 uuid = "4ef9e186-2fe5-4b24-8de7-9f7291f24af7"
 authors = ["Sebastijan Dumancic <s.dumancic@tudelft.nl>", "Jaap de Jong <J.deJong-18@student.tudelft.nl>", "Nicolae Filat <N.Filat@student.tudelft.nl>", "Piotr Cichoń <gitlab@gitlab.ewi.tudelft.nl>"]
-version = "1.1.3"
+version = "1.2.0"
 
 [workspace]
 projects = ["test"]

--- a/src/grammar_base.jl
+++ b/src/grammar_base.jl
@@ -206,18 +206,26 @@ end
 
 
 """
-    add_rule!(g::AbstractGrammar, p::Real, e::Expr)
+    add_rule!(g::AbstractGrammar, p::Real, e::Expr; normalize=true)
 
-Adds a probabilistic derivation rule.
+Add a probabilistic derivation rule.
+
+!!! note
+    By default, normalizes the grammar `g`'s probabilities after adding the rule(s).
+    When constructing a grammar iteratively, it may be useful to skip normalization
+    until all rules and their probabilities have been added, calling
+    [`normalize!`](@ref) at the end.
 """
-function add_rule!(g::AbstractGrammar, p::Real, e::Expr)
+function add_rule!(g::AbstractGrammar, p::Real, e::Expr; normalize=true)
     isprobabilistic(g) || throw(ArgumentError("adding a probabilistic rule to a non-probabilistic grammar"))
     len₀ = length(g.rules)
     add_rule!(g, e)
     len₁ = length(g.rules)
     nnew = len₁ - len₀
     append!(g.log_probabilities, repeat([log(p / nnew)], nnew))
-    normalize!(g)
+    if normalize
+        normalize!(g)
+    end
 end
 
 """


### PR DESCRIPTION
Skipping normalization makes it easier to add rules when constructing a grammar iteratively.